### PR TITLE
fix(storage): reset SQL engines after temp event loop init

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -317,6 +317,15 @@ repos:
             }
             exit 0
 
+      - id: block-sql-data-ops-in-initialize
+        name: Block SQL data ops in initialize() methods
+        entry: ./scripts/check-no-sql-in-initialize.sh
+        language: script
+        types: [python]
+        pass_filenames: false
+        always_run: true
+        files: ^src/ogx/(providers|core)/
+
       - id: enforce-authorized-sqlstore
         name: Enforce AuthorizedSqlStore usage
         entry: bash

--- a/scripts/check-no-sql-in-initialize.sh
+++ b/scripts/check-no-sql-in-initialize.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+# Block SQL data operations (fetch_all, fetch_one, insert, update, delete)
+# inside initialize() methods in provider and core code.
+#
+# These operations trigger _ensure_engine() which binds the SQL engine to the
+# current event loop. During Stack.initialize() this is a temporary loop —
+# the engine will fail at request time with "Future attached to a different loop".
+#
+# Allowed: create_table(), add_column_if_not_exists() (metadata-only, no engine).
+# Blocked: fetch_all(), fetch_one(), insert(), update(), delete() (trigger engine).
+
+set -euo pipefail
+
+BLOCKED_OPS='\.fetch_all\(|\.fetch_one\(|\.insert\(|\.update\(|\.delete\('
+SEARCH_DIRS="src/ogx/providers src/ogx/core"
+EXCLUDE_DIR="src/ogx/core/storage"
+
+found_violations=false
+
+for dir in $SEARCH_DIRS; do
+    [ -d "$dir" ] || continue
+
+    # Find Python files, excluding the storage implementation itself
+    while IFS= read -r file; do
+        # Use awk to detect blocked operations inside initialize() method bodies
+        result=$(awk '
+            /^[[:space:]]*(async[[:space:]]+)?def[[:space:]]+initialize[[:space:]]*\(/ {
+                in_init = 1
+                init_indent = 0
+                match($0, /^[[:space:]]*/)
+                init_indent = RLENGTH
+                next
+            }
+            in_init && /^[[:space:]]*(async[[:space:]]+)?def[[:space:]]+[a-zA-Z_]/ {
+                match($0, /^[[:space:]]*/)
+                if (RLENGTH <= init_indent) {
+                    in_init = 0
+                }
+            }
+            in_init && /\.(fetch_all|fetch_one|insert|update|delete)\(/ {
+                # Skip lines that are comments
+                stripped = $0
+                sub(/^[[:space:]]*/, "", stripped)
+                if (substr(stripped, 1, 1) != "#") {
+                    printf "%s:%d: %s\n", FILENAME, NR, $0
+                }
+            }
+        ' "$file")
+
+        if [ -n "$result" ]; then
+            found_violations=true
+            echo "$result"
+        fi
+    done < <(find "$dir" -name "*.py" -not -path "${EXCLUDE_DIR}/*")
+done
+
+if [ "$found_violations" = true ]; then
+    echo
+    echo "❌ SQL data operations detected inside initialize() methods."
+    echo "These trigger _ensure_engine() which binds the SQL engine to the"
+    echo "current event loop. During Stack.initialize() this is a temporary"
+    echo "loop — the engine will fail at request time."
+    echo
+    echo "Allowed in initialize(): create_table(), add_column_if_not_exists()"
+    echo "Blocked in initialize(): fetch_all(), fetch_one(), insert(), update(), delete()"
+    echo
+    echo "Move data operations to a separate method called after server startup,"
+    echo "or use the lifespan handler."
+    exit 1
+fi

--- a/src/ogx/core/server/server.py
+++ b/src/ogx/core/server/server.py
@@ -120,6 +120,13 @@ class StackApp(FastAPI):
             future = executor.submit(asyncio.run, self.stack.initialize())  # type: ignore[no-untyped-call]
             future.result()
 
+        # Reset SQL engines that may have been created in the temporary event loop
+        # (e.g. by register_connectors → list_connectors → fetch_all) so they are
+        # recreated lazily in uvicorn's request-handling event loop.
+        from ogx.core.storage.sqlstore.sqlstore import reset_sqlstore_engines
+
+        reset_sqlstore_engines()
+
 
 @asynccontextmanager
 async def lifespan(app: StackApp) -> AsyncIterator[None]:

--- a/src/ogx/core/stack.py
+++ b/src/ogx/core/stack.py
@@ -734,6 +734,11 @@ class Stack:
                 logger.info("API recording enabled", mode=os.environ.get("OGX_TEST_INFERENCE_MODE"))
 
         _initialize_storage(self.run_config)
+
+        from ogx.core.storage.sqlstore.sqlstore import set_sqlstore_init_phase
+
+        set_sqlstore_init_phase(True)
+
         stores = self.run_config.storage.stores
         if not stores.metadata:
             raise ValueError("storage.stores.metadata must be configured with a kv_* backend")
@@ -763,6 +768,9 @@ class Stack:
         await register_connectors(self.run_config, impls)
         await refresh_registry_once(impls)
         await validate_vector_stores_config(self.run_config.vector_stores, impls)
+
+        set_sqlstore_init_phase(False)
+
         self.impls = impls
 
     def create_registry_refresh_task(self):

--- a/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
@@ -106,6 +106,16 @@ class SqlAlchemySqlStoreImpl(SqlStore):
                     await self._add_column_now(table_name, col_name, col_type, nullable)
             self._pending_columns.clear()
 
+    def reset_engine(self) -> None:
+        """Reset engine state so it will be recreated in the next event loop.
+
+        Called after Stack.initialize() completes in a temporary event loop,
+        before uvicorn's request-handling loop takes over. Does not dispose
+        the old engine because the temporary loop is already closed.
+        """
+        self._engine = None
+        self.async_session = None
+
     async def shutdown(self) -> None:
         """Dispose of the async engine and close all connections."""
         if self._engine:

--- a/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlalchemy_sqlstore.py
@@ -83,6 +83,10 @@ class SqlAlchemySqlStoreImpl(SqlStore):
         self._pending_columns: dict[
             str, list[tuple[str, ColumnType, bool]]
         ] = {}  # table -> [(col_name, col_type, nullable)]
+        self._init_phase: bool = False
+
+    def _set_init_phase(self, active: bool) -> None:
+        self._init_phase = active
 
     async def _ensure_engine(self) -> None:
         """Lazy initialization: create engine on first use in the current event loop.
@@ -90,6 +94,15 @@ class SqlAlchemySqlStoreImpl(SqlStore):
         This fixes event loop mismatch issues when Stack is initialized in a different
         event loop (e.g., ThreadPoolExecutor) than request handling (uvicorn's loop).
         """
+        if self._init_phase and self._engine is None:
+            import traceback
+
+            logger.warning(
+                "SQL engine created during init phase — this will cause event loop "
+                "mismatch errors at request time. Move this data operation out of "
+                "initialize() or ensure reset_sqlstore_engines() runs after init.",
+                caller=traceback.format_stack()[-3].strip(),
+            )
         if self._engine is None:
             # Create engine in the current running event loop
             self._engine = self.create_engine()

--- a/src/ogx/core/storage/sqlstore/sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlstore.py
@@ -98,6 +98,17 @@ def register_sqlstore_backends(backends: dict[str, StorageBackendConfig]) -> Non
         _SQLSTORE_BACKENDS[name] = cfg
 
 
+def reset_sqlstore_engines() -> None:
+    """Reset engines on all cached SqlStore instances.
+
+    Called after Stack.initialize() completes in a temporary event loop so
+    engines are recreated lazily in uvicorn's request-handling event loop.
+    """
+    for instance in _SQLSTORE_INSTANCES.values():
+        if hasattr(instance, "reset_engine"):
+            instance.reset_engine()
+
+
 async def shutdown_sqlstore_backends() -> None:
     """Shutdown all cached SQL store instances."""
     global _SQLSTORE_INSTANCES

--- a/src/ogx/core/storage/sqlstore/sqlstore.py
+++ b/src/ogx/core/storage/sqlstore/sqlstore.py
@@ -98,6 +98,18 @@ def register_sqlstore_backends(backends: dict[str, StorageBackendConfig]) -> Non
         _SQLSTORE_BACKENDS[name] = cfg
 
 
+def set_sqlstore_init_phase(active: bool) -> None:
+    """Mark all cached SqlStore instances as being in the init phase.
+
+    During init phase, _ensure_engine() logs a warning if triggered, since
+    the engine would be bound to the temporary event loop used by
+    Stack.initialize() rather than uvicorn's request-handling loop.
+    """
+    for instance in _SQLSTORE_INSTANCES.values():
+        if hasattr(instance, "_set_init_phase"):
+            instance._set_init_phase(active)
+
+
 def reset_sqlstore_engines() -> None:
     """Reset engines on all cached SqlStore instances.
 

--- a/src/ogx/providers/utils/inference/inference_store.py
+++ b/src/ogx/providers/utils/inference/inference_store.py
@@ -6,6 +6,7 @@
 import asyncio
 from typing import Any, NamedTuple
 
+from opentelemetry import metrics
 from sqlalchemy.exc import IntegrityError
 
 from ogx.core.datatypes import AccessRule
@@ -19,6 +20,10 @@ from ogx.core.task import (
     create_detached_background_task,
 )
 from ogx.log import get_logger
+from ogx.telemetry.constants import (
+    INFERENCE_STORE_WRITE_ERRORS_TOTAL,
+    INFERENCE_STORE_WRITES_TOTAL,
+)
 from ogx_api import (
     ChatCompletionMessage,
     ChatCompletionMessageList,
@@ -33,6 +38,16 @@ from ogx_api import (
 from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType
 
 logger = get_logger(name=__name__, category="inference")
+
+_meter = metrics.get_meter("ogx.inference.store", version="1.0.0")
+store_writes_total = _meter.create_counter(
+    name=INFERENCE_STORE_WRITES_TOTAL,
+    description="Total successful inference store writes",
+)
+store_write_errors_total = _meter.create_counter(
+    name=INFERENCE_STORE_WRITE_ERRORS_TOTAL,
+    description="Total failed inference store writes",
+)
 
 
 class _WriteItem(NamedTuple):
@@ -202,6 +217,7 @@ class InferenceStore:
                 with activate_request_context(item.request_context):
                     await self._write_chat_completion(item.completion, item.messages)
             except Exception as e:  # noqa: BLE001
+                store_write_errors_total.add(1)
                 logger.error("Error writing chat completion", error=str(e))
             finally:
                 self._queue.task_done()
@@ -226,6 +242,7 @@ class InferenceStore:
                 table=self.reference.table_name,
                 data=record_data,
             )
+            store_writes_total.add(1)
         except IntegrityError as e:
             # Duplicate chat completion IDs can be generated during tests especially if they are replaying
             # recorded responses across different tests. No need to warn or error under those circumstances.
@@ -236,6 +253,7 @@ class InferenceStore:
             if self._is_unique_constraint_error(error_message):
                 # Update the existing record instead
                 await self.sql_store.update(table=self.reference.table_name, data=record_data, where={"id": data["id"]})
+                store_writes_total.add(1)
             else:
                 # Re-raise if it's not a unique constraint error
                 raise

--- a/src/ogx/telemetry/constants.py
+++ b/src/ogx/telemetry/constants.py
@@ -54,6 +54,10 @@ INFERENCE_DURATION = f"{INFERENCE_PREFIX}.duration_seconds"
 INFERENCE_TIME_TO_FIRST_TOKEN = f"{INFERENCE_PREFIX}.time_to_first_token_seconds"
 INFERENCE_TOKENS_PER_SECOND = f"{INFERENCE_PREFIX}.tokens_per_second"
 
+# Inference Store Metrics
+INFERENCE_STORE_WRITES_TOTAL = f"{INFERENCE_PREFIX}.store_writes_total"
+INFERENCE_STORE_WRITE_ERRORS_TOTAL = f"{INFERENCE_PREFIX}.store_write_errors_total"
+
 # Responses API Metrics
 RESPONSES_PREFIX = f"{ogx_prefix}.responses"
 RESPONSES_PARAMETER_USAGE_TOTAL = f"{RESPONSES_PREFIX}.parameter_usage_total"

--- a/tests/unit/core/test_inference_store_event_loop.py
+++ b/tests/unit/core/test_inference_store_event_loop.py
@@ -106,9 +106,7 @@ def test_inference_store_write_queue_after_event_loop_reset(tmp_path):
         store._worker_tasks = []
 
         for i in range(3):
-            await store.store_chat_completion(
-                _make_completion(f"cmpl-{i}", created=1000 + i), _make_messages()
-            )
+            await store.store_chat_completion(_make_completion(f"cmpl-{i}", created=1000 + i), _make_messages())
         await store.flush()
 
         result = await store.list_chat_completions()

--- a/tests/unit/core/test_inference_store_event_loop.py
+++ b/tests/unit/core/test_inference_store_event_loop.py
@@ -1,0 +1,146 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Tests that InferenceStore works across event loop boundaries after engine reset.
+
+Simulates the actual server startup pattern where Stack.initialize() runs in a
+temporary event loop and request handling runs in uvicorn's event loop.
+"""
+
+import asyncio
+
+from ogx.core.storage.datatypes import InferenceStoreReference, SqliteSqlStoreConfig
+from ogx.core.storage.sqlstore.sqlstore import register_sqlstore_backends, reset_sqlstore_engines
+from ogx.providers.utils.inference.inference_store import InferenceStore
+from ogx_api import (
+    OpenAIChatCompletion,
+    OpenAIChatCompletionResponseMessage,
+    OpenAIChoice,
+    OpenAIUserMessageParam,
+)
+
+
+def _make_completion(completion_id: str) -> OpenAIChatCompletion:
+    return OpenAIChatCompletion(
+        id=completion_id,
+        created=1000,
+        model="test-model",
+        object="chat.completion",
+        choices=[
+            OpenAIChoice(
+                index=0,
+                message=OpenAIChatCompletionResponseMessage(role="assistant", content="hello"),
+                finish_reason="stop",
+            )
+        ],
+    )
+
+
+def _make_messages():
+    return [OpenAIUserMessageParam(role="user", content="hi")]
+
+
+def test_inference_store_data_persisted_after_event_loop_reset(tmp_path):
+    """Data written via store_chat_completion is retrievable after engine reset.
+
+    Uses direct writes (SQLite disables the write queue) to verify that the
+    SQL engine is properly recreated and data reaches the database.
+    """
+    db_path = str(tmp_path / "inference.db")
+    register_sqlstore_backends({"sql_default": SqliteSqlStoreConfig(db_path=db_path)})
+
+    reference = InferenceStoreReference(backend="sql_default", table_name="inference_store")
+
+    async def init_phase():
+        store = InferenceStore(reference, policy=[])
+        await store.initialize()
+        return store
+
+    store = asyncio.run(init_phase())
+
+    reset_sqlstore_engines()
+
+    async def request_phase():
+        await store.store_chat_completion(_make_completion("cmpl-1"), _make_messages())
+        await store.flush()
+        result = await store.list_chat_completions()
+        return result
+
+    result = asyncio.run(request_phase())
+    assert len(result.data) == 1
+    assert result.data[0].id == "cmpl-1"
+    assert result.data[0].choices[0].message.content == "hello"
+    assert len(result.data[0].input_messages) == 1
+
+
+def test_inference_store_write_queue_after_event_loop_reset(tmp_path):
+    """Write queue workers function correctly after engine reset.
+
+    Forces enable_write_queue=True (normally disabled for SQLite) to exercise
+    the background worker path that fails with 'Future attached to a different
+    loop' when the engine is bound to the wrong event loop.
+    """
+    db_path = str(tmp_path / "inference.db")
+    register_sqlstore_backends({"sql_default": SqliteSqlStoreConfig(db_path=db_path)})
+
+    reference = InferenceStoreReference(backend="sql_default", table_name="inference_store")
+
+    async def init_phase():
+        store = InferenceStore(reference, policy=[])
+        await store.initialize()
+        return store
+
+    store = asyncio.run(init_phase())
+
+    reset_sqlstore_engines()
+
+    async def request_phase():
+        # Force write queue on to simulate PostgreSQL behavior
+        store.enable_write_queue = True
+        store._queue = None
+        store._worker_tasks = []
+
+        for i in range(3):
+            await store.store_chat_completion(_make_completion(f"cmpl-{i}"), _make_messages())
+        await store.flush()
+
+        result = await store.list_chat_completions()
+        await store.shutdown()
+        return result
+
+    result = asyncio.run(request_phase())
+    assert len(result.data) == 3
+    ids = {r.id for r in result.data}
+    assert ids == {"cmpl-0", "cmpl-1", "cmpl-2"}
+
+
+def test_inference_store_retrieve_after_event_loop_reset(tmp_path):
+    """Individual completion retrieval works after engine reset."""
+    db_path = str(tmp_path / "inference.db")
+    register_sqlstore_backends({"sql_default": SqliteSqlStoreConfig(db_path=db_path)})
+
+    reference = InferenceStoreReference(backend="sql_default", table_name="inference_store")
+
+    async def init_phase():
+        store = InferenceStore(reference, policy=[])
+        await store.initialize()
+        return store
+
+    store = asyncio.run(init_phase())
+
+    reset_sqlstore_engines()
+
+    async def request_phase():
+        await store.store_chat_completion(_make_completion("cmpl-42"), _make_messages())
+        await store.flush()
+
+        completion = await store.get_chat_completion("cmpl-42")
+        return completion
+
+    completion = asyncio.run(request_phase())
+    assert completion.id == "cmpl-42"
+    assert completion.choices[0].message.content == "hello"
+    assert completion.input_messages[0].content == "hi"

--- a/tests/unit/core/test_inference_store_event_loop.py
+++ b/tests/unit/core/test_inference_store_event_loop.py
@@ -23,10 +23,10 @@ from ogx_api import (
 )
 
 
-def _make_completion(completion_id: str) -> OpenAIChatCompletion:
+def _make_completion(completion_id: str, created: int = 1000) -> OpenAIChatCompletion:
     return OpenAIChatCompletion(
         id=completion_id,
-        created=1000,
+        created=created,
         model="test-model",
         object="chat.completion",
         choices=[
@@ -98,13 +98,17 @@ def test_inference_store_write_queue_after_event_loop_reset(tmp_path):
     reset_sqlstore_engines()
 
     async def request_phase():
-        # Force write queue on to simulate PostgreSQL behavior
+        # Force write queue on with a single writer to simulate PostgreSQL
+        # behavior. Multiple writers race on SQLite, so use one worker.
         store.enable_write_queue = True
+        store._num_writers = 1
         store._queue = None
         store._worker_tasks = []
 
         for i in range(3):
-            await store.store_chat_completion(_make_completion(f"cmpl-{i}"), _make_messages())
+            await store.store_chat_completion(
+                _make_completion(f"cmpl-{i}", created=1000 + i), _make_messages()
+            )
         await store.flush()
 
         result = await store.list_chat_completions()

--- a/tests/unit/core/test_server_lifecycle.py
+++ b/tests/unit/core/test_server_lifecycle.py
@@ -1,0 +1,151 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Tests that the server startup lifecycle correctly resets SQL engines.
+
+Verifies that after Stack.initialize() runs in a temporary event loop,
+SQL engines are reset so they can be recreated in uvicorn's request loop.
+"""
+
+import asyncio
+import logging
+
+from ogx.core.storage.datatypes import SqliteSqlStoreConfig
+from ogx.core.storage.sqlstore.sqlalchemy_sqlstore import SqlAlchemySqlStoreImpl
+from ogx.core.storage.sqlstore.sqlstore import (
+    _SQLSTORE_INSTANCES,
+    register_sqlstore_backends,
+    reset_sqlstore_engines,
+    set_sqlstore_init_phase,
+)
+from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType
+
+
+def test_reset_sqlstore_engines_clears_all_instances(tmp_path):
+    """reset_sqlstore_engines() resets engine on every cached instance."""
+    db_path = str(tmp_path / "test.db")
+    register_sqlstore_backends({"sql_default": SqliteSqlStoreConfig(db_path=db_path)})
+
+    async def create_engine():
+        from ogx.core.storage.sqlstore.sqlstore import _sqlstore_impl
+
+        store = await _sqlstore_impl(
+            type("Ref", (), {"backend": "sql_default", "table_name": "t"})()  # type: ignore[arg-type]
+        )
+        await store.create_table("t", {"id": ColumnDefinition(type=ColumnType.STRING, primary_key=True)})
+        await store.insert("t", {"id": "1"})
+        return store
+
+    store = asyncio.run(create_engine())
+    assert store._engine is not None
+
+    reset_sqlstore_engines()
+
+    for instance in _SQLSTORE_INSTANCES.values():
+        assert instance._engine is None
+
+
+def test_init_phase_warning_on_ensure_engine(tmp_path, caplog):
+    """_ensure_engine() logs a warning when called during init phase."""
+    db_path = str(tmp_path / "test.db")
+    store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+    store._set_init_phase(True)
+
+    async def trigger():
+        await store.create_table("t", {"id": ColumnDefinition(type=ColumnType.STRING, primary_key=True)})
+        with caplog.at_level(logging.WARNING):
+            await store.insert("t", {"id": "1"})
+
+    asyncio.run(trigger())
+    assert any("SQL engine created during init phase" in r.message for r in caplog.records)
+    await_cleanup(store)
+
+
+def test_no_init_phase_warning_outside_init(tmp_path, caplog):
+    """_ensure_engine() does not warn when init phase is inactive."""
+    db_path = str(tmp_path / "test.db")
+    store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+
+    async def trigger():
+        await store.create_table("t", {"id": ColumnDefinition(type=ColumnType.STRING, primary_key=True)})
+        with caplog.at_level(logging.WARNING):
+            await store.insert("t", {"id": "1"})
+
+    asyncio.run(trigger())
+    assert not any("SQL engine created during init phase" in r.message for r in caplog.records)
+    await_cleanup(store)
+
+
+def test_set_sqlstore_init_phase_propagates(tmp_path):
+    """set_sqlstore_init_phase() sets the flag on all cached instances."""
+    db_path = str(tmp_path / "test.db")
+    register_sqlstore_backends({"sql_default": SqliteSqlStoreConfig(db_path=db_path)})
+
+    async def create():
+        from ogx.core.storage.sqlstore.sqlstore import _sqlstore_impl
+
+        return await _sqlstore_impl(
+            type("Ref", (), {"backend": "sql_default", "table_name": "t"})()  # type: ignore[arg-type]
+        )
+
+    store = asyncio.run(create())
+
+    set_sqlstore_init_phase(True)
+    assert store._init_phase is True
+
+    set_sqlstore_init_phase(False)
+    assert store._init_phase is False
+
+
+def test_server_init_lifecycle_engines_reset_after_init(tmp_path):
+    """Simulates the full server init lifecycle: init in temp loop → reset → use in new loop."""
+    db_path = str(tmp_path / "test.db")
+    register_sqlstore_backends({"sql_default": SqliteSqlStoreConfig(db_path=db_path)})
+
+    async def init_in_temp_loop():
+        from ogx.core.storage.sqlstore.sqlstore import _sqlstore_impl
+
+        set_sqlstore_init_phase(True)
+
+        store = await _sqlstore_impl(
+            type("Ref", (), {"backend": "sql_default", "table_name": "t"})()  # type: ignore[arg-type]
+        )
+        await store.create_table(
+            "lifecycle_test",
+            {"id": ColumnDefinition(type=ColumnType.STRING, primary_key=True), "value": ColumnType.STRING},
+        )
+        # Simulate register_connectors triggering _ensure_engine
+        await store.insert("lifecycle_test", {"id": "init_row", "value": "from_init"})
+
+        set_sqlstore_init_phase(False)
+        return store
+
+    store = asyncio.run(init_in_temp_loop())
+    assert store._engine is not None
+
+    # Server does this after Stack.initialize() returns
+    reset_sqlstore_engines()
+    assert store._engine is None
+
+    # Simulate request-phase usage in a new event loop
+    async def use_in_request_loop():
+        await store.insert("lifecycle_test", {"id": "request_row", "value": "from_request"})
+        result = await store.fetch_all("lifecycle_test")
+        return result
+
+    result = asyncio.run(use_in_request_loop())
+    assert len(result.data) == 2
+    ids = {row["id"] for row in result.data}
+    assert ids == {"init_row", "request_row"}
+
+
+def await_cleanup(store: SqlAlchemySqlStoreImpl) -> None:
+    """Best-effort engine cleanup for test isolation."""
+    if store._engine is not None:
+        try:
+            asyncio.run(store.shutdown())
+        except Exception:
+            store._engine = None

--- a/tests/unit/core/test_sqlstore_event_loop.py
+++ b/tests/unit/core/test_sqlstore_event_loop.py
@@ -1,0 +1,109 @@
+# Copyright (c) The OGX Contributors.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+"""Tests that SqlAlchemySqlStoreImpl works correctly across event loop boundaries."""
+
+import asyncio
+
+import pytest
+
+from ogx.core.storage.datatypes import SqliteSqlStoreConfig
+from ogx.core.storage.sqlstore.sqlalchemy_sqlstore import SqlAlchemySqlStoreImpl
+from ogx_api.internal.sqlstore import ColumnDefinition, ColumnType
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "test_loop.db")
+
+
+def test_reset_engine_clears_state(db_path):
+    """reset_engine() sets engine and session to None."""
+    store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+
+    async def init():
+        await store.create_table("t", {"id": ColumnDefinition(type=ColumnType.STRING, primary_key=True)})
+        await store.insert("t", {"id": "1"})
+
+    asyncio.run(init())
+    assert store._engine is not None
+    assert store.async_session is not None
+
+    store.reset_engine()
+    assert store._engine is None
+    assert store.async_session is None
+
+
+def test_reset_engine_preserves_metadata(db_path):
+    """reset_engine() preserves table metadata so _ensure_engine recreates tables."""
+    store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+
+    async def init():
+        await store.create_table("t", {"id": ColumnDefinition(type=ColumnType.STRING, primary_key=True)})
+
+    asyncio.run(init())
+    assert "t" in store.metadata.tables
+
+    store.reset_engine()
+    assert "t" in store.metadata.tables
+
+
+def test_data_survives_engine_reset(db_path):
+    """Data written before reset_engine() is accessible after engine recreation."""
+    store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+
+    async def phase1():
+        await store.create_table(
+            "items",
+            {
+                "id": ColumnDefinition(type=ColumnType.STRING, primary_key=True),
+                "value": ColumnType.STRING,
+            },
+        )
+        await store.insert("items", {"id": "row1", "value": "before_reset"})
+
+    asyncio.run(phase1())
+    store.reset_engine()
+
+    async def phase2():
+        await store.insert("items", {"id": "row2", "value": "after_reset"})
+        result = await store.fetch_all("items")
+        return result
+
+    result = asyncio.run(phase2())
+    ids = {row["id"] for row in result.data}
+    assert ids == {"row1", "row2"}
+
+
+def test_engine_reset_across_event_loops(db_path):
+    """Simulates the server init pattern: init in one loop, use in another."""
+    store = SqlAlchemySqlStoreImpl(SqliteSqlStoreConfig(db_path=db_path))
+
+    async def init_in_temp_loop():
+        await store.create_table(
+            "items",
+            {
+                "id": ColumnDefinition(type=ColumnType.STRING, primary_key=True),
+                "value": ColumnType.STRING,
+            },
+        )
+        await store.insert("items", {"id": "init_row", "value": "from_init"})
+        result = await store.fetch_all("items")
+        assert len(result.data) == 1
+
+    asyncio.run(init_in_temp_loop())
+
+    store.reset_engine()
+
+    async def use_in_request_loop():
+        await store.insert("items", {"id": "request_row", "value": "from_request"})
+        result = await store.fetch_all("items")
+        return result
+
+    result = asyncio.run(use_in_request_loop())
+    assert len(result.data) == 2
+    ids = {row["id"] for row in result.data}
+    assert ids == {"init_row", "request_row"}


### PR DESCRIPTION
# What does this PR do?

Fixes `inference_store` table not being populated after the KV-to-SQL migration of connectors (PR #5757). `Stack.initialize()` runs in a temporary event loop via `ThreadPoolExecutor`. After the migration, `register_connectors()` → `list_connectors()` triggers `_ensure_engine()` during init, binding the asyncpg engine to the temp loop. When uvicorn's request loop takes over, `InferenceStore` write queue workers fail silently with `"got Future attached to a different loop"`, dropping all chat completion records.

The fix adds `reset_engine()` to `SqlAlchemySqlStoreImpl` and calls `reset_sqlstore_engines()` after `Stack.initialize()` returns, so engines are recreated lazily in the correct event loop. Table metadata is preserved across the reset, so `_ensure_engine()` re-creates all tables via `metadata.create_all(checkfirst=True)` on first use.

## Test Plan

New unit tests covering the event loop reset behavior:

```bash
uv run pytest tests/unit/core/test_sqlstore_event_loop.py tests/unit/core/test_inference_store_event_loop.py -x --tb=short -v
```

Output:
```
tests/unit/core/test_sqlstore_event_loop.py::test_reset_engine_clears_state PASSED
tests/unit/core/test_sqlstore_event_loop.py::test_reset_engine_preserves_metadata PASSED
tests/unit/core/test_sqlstore_event_loop.py::test_data_survives_engine_reset PASSED
tests/unit/core/test_sqlstore_event_loop.py::test_engine_reset_across_event_loops PASSED
tests/unit/core/test_inference_store_event_loop.py::test_inference_store_data_persisted_after_event_loop_reset PASSED
tests/unit/core/test_inference_store_event_loop.py::test_inference_store_write_queue_after_event_loop_reset PASSED
tests/unit/core/test_inference_store_event_loop.py::test_inference_store_retrieve_after_event_loop_reset PASSED
7 passed
```

Key test: `test_inference_store_write_queue_after_event_loop_reset` forces `enable_write_queue=True` to simulate the PostgreSQL background worker path that fails without this fix.

Existing tests unaffected:
```bash
uv run pytest tests/unit/core/test_sqlstore_add_column.py tests/unit/utils/inference/test_inference_store.py tests/unit/core/connectors/ -x --tb=short
# 44 passed
```